### PR TITLE
apply deterministic order to farm listings (sorting alphabetically)

### DIFF
--- a/usr/share/perl5/Zevenet/Farm/Core.pm
+++ b/usr/share/perl5/Zevenet/Farm/Core.pm
@@ -168,21 +168,15 @@ sub getFarmList    # ()
 {
 	&zenlog( __FILE__ . ":" . __LINE__ . ":" . ( caller ( 0 ) )[3] . "( @_ )",
 			 "debug", "PROFILING" );
-	opendir ( DIR, $configdir );
-	my @files1 = grep ( /\_pound.cfg$/, readdir ( DIR ) );
-	closedir ( DIR );
 
 	opendir ( DIR, $configdir );
-	my @files2 = grep ( /\_datalink.cfg$/, readdir ( DIR ) );
+	my @cfgFiles = sort ( grep ( /\.cfg$/, readdir ( DIR ) ) );
 	closedir ( DIR );
 
-	opendir ( DIR, $configdir );
-	my @files3 = grep ( /\_l4xnat.cfg$/, readdir ( DIR ) );
-	closedir ( DIR );
-
-	opendir ( DIR, $configdir );
-	my @files4 = grep ( /\_gslb.cfg$/, readdir ( DIR ) );
-	closedir ( DIR );
+	my @files1 = grep ( /_pound\.cfg$/, @cfgFiles );
+	my @files2 = grep ( /_datalink\.cfg$/, @cfgFiles );
+	my @files3 = grep ( /_l4xnat\.cfg$/, @cfgFiles );
+	my @files4 = grep ( /_gslb\.cfg$/, @cfgFiles );
 
 	my @files = ( @files1, @files2, @files3, @files4 );
 


### PR DESCRIPTION
A very small change to Core.pm to get the farms to be listed in a friendlier and more deterministic order internally, also affecting ZAPI and improving the CE GUI, just sorting the entries alphabetically by name.

I also changed the regular expressions used in grep to escape the "." in .cfg, rather than an "_" which didn't need to be escaped, and modified it to only get the directory listing once and reuse it.

Although the source code in GitHub appears to be out of sync with the latest release 5.9.3, which is what we are running, I hope this change will merge cleanly and can be added to future releases.